### PR TITLE
fix(createBrowserLikeFetch): remove null cookie options

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -46,7 +46,7 @@ describe('createCookiePassingFetch', () => {
     expect(setCookie.mock.calls[0][2].maxAge).toEqual(3600000);
   });
 
-  it('correctly sets max-age', async () => {
+  it('does not add missing propterties', async () => {
     const mockFetch = jest.fn(() => Promise.resolve({
       headers: new Headers({
         'set-cookie': [
@@ -65,7 +65,7 @@ describe('createCookiePassingFetch', () => {
       credentials: 'include',
     });
 
-    // express sets cookies max age in milliseconds rather than seconds
+    // if null values are not removed this will fail
     expect(setCookie.mock.calls[0][2].maxAge).toBe(undefined);
   });
 

--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -46,6 +46,29 @@ describe('createCookiePassingFetch', () => {
     expect(setCookie.mock.calls[0][2].maxAge).toEqual(3600000);
   });
 
+  it('correctly sets max-age', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'sessionId=1234rlakjhf; Domain=example.com; Path=/path/; HttpOnly;',
+        ],
+      }),
+    }));
+    const hostname = 'api.example.com';
+    const setCookie = jest.fn();
+    const fetchWithRequestHeaders = createBrowserLikeFetch({
+      hostname,
+      setCookie,
+    })(mockFetch);
+
+    await fetchWithRequestHeaders('https://example.com', {
+      credentials: 'include',
+    });
+
+    // express sets cookies max age in milliseconds rather than seconds
+    expect(setCookie.mock.calls[0][2].maxAge).toBe(undefined);
+  });
+
   it('does not call setCookie with mismatching domain on response', async () => {
     const mockFetch = jest.fn(() => Promise.resolve({
       headers: new Headers({

--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -46,7 +46,7 @@ describe('createCookiePassingFetch', () => {
     expect(setCookie.mock.calls[0][2].maxAge).toEqual(3600000);
   });
 
-  it('does not add missing propterties', async () => {
+  it('does not add missing properties', async () => {
     const mockFetch = jest.fn(() => Promise.resolve({
       headers: new Headers({
         'set-cookie': [

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -62,9 +62,12 @@ function createBrowserLikeFetch({
               const value = decodeURIComponent(valueRaw);
               const cookieDomain = cookieOptions.domain;
               if (cookieDomain && `.${cookieDomain}`.endsWith(`.${hostname.split('.').slice(-2).join('.')}`)) {
+                // remove null values from cookieOptions
+                const filteredOptions = Object.fromEntries(Object.entries(cookieOptions)
+                  .filter(([, propertyValue]) => propertyValue != null));
                 const expressCookieOptions = {
-                  ...cookieOptions,
-                  ...cookieOptions.maxAge ? { maxAge: cookieOptions.maxAge * 1e3 } : undefined,
+                  ...filteredOptions,
+                  ...filteredOptions.maxAge ? { maxAge: cookieOptions.maxAge * 1e3 } : undefined,
                 };
                 res.cookie(key, value, expressCookieOptions);
               }


### PR DESCRIPTION
tough-cookie's parse returns `null` for properties not defined by the cookie string. Express's `response.cookie`  sets null values as `0`. This resulted in cookies with no max age being set as having a max age of `0` which instantly expired that cookie. 