### PR TITLE
fix(expires): defaults to undefined

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -69,6 +69,29 @@ describe('createCookiePassingFetch', () => {
     expect(setCookie.mock.calls[0][2].maxAge).toBe(undefined);
   });
 
+  it('does not add expires if set to Infinity', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'sessionId=1234rlakjhf; Domain=example.com; Path=/path/; HttpOnly;',
+        ],
+      }),
+    }));
+    const hostname = 'api.example.com';
+    const setCookie = jest.fn();
+    const fetchWithRequestHeaders = createBrowserLikeFetch({
+      hostname,
+      setCookie,
+    })(mockFetch);
+
+    await fetchWithRequestHeaders('https://example.com', {
+      credentials: 'include',
+    });
+
+    // if null values are not removed this will fail
+    expect(setCookie.mock.calls[0][2].expires).toBe(undefined);
+  });
+
   it('does not call setCookie with mismatching domain on response', async () => {
     const mockFetch = jest.fn(() => Promise.resolve({
       headers: new Headers({

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -57,26 +57,14 @@ function createBrowserLikeFetch({
 
           cookieStrings.forEach((cookieString) => {
             const cookie = parse(cookieString);
-            const { key, value: valueRaw, ...cookieOptions } = cookie;
+            const { key, value: valueRaw, ...cookieOptions } = cookie.toJSON();
             try {
               const value = decodeURIComponent(valueRaw);
               const cookieDomain = cookieOptions.domain;
               if (cookieDomain && `.${cookieDomain}`.endsWith(`.${hostname.split('.').slice(-2).join('.')}`)) {
-                const filteredOptions = Object.fromEntries(Object.entries(cookieOptions)
-                  .filter(([propertyKey, propertyValue]) => {
-                    // remove expires set to Infinity by default
-                    if (propertyKey === 'expires' && propertyValue === 'Infinity') {
-                      return false;
-                    }
-                    // remove null values from cookieOptions
-                    if (propertyValue != null) {
-                      return true;
-                    }
-                    return false;
-                  }));
                 const expressCookieOptions = {
-                  ...filteredOptions,
-                  ...filteredOptions.maxAge ? { maxAge: cookieOptions.maxAge * 1e3 } : undefined,
+                  ...cookieOptions,
+                  ...cookieOptions.maxAge ? { maxAge: cookieOptions.maxAge * 1e3 } : undefined,
                 };
                 res.cookie(key, value, expressCookieOptions);
               }

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -62,9 +62,18 @@ function createBrowserLikeFetch({
               const value = decodeURIComponent(valueRaw);
               const cookieDomain = cookieOptions.domain;
               if (cookieDomain && `.${cookieDomain}`.endsWith(`.${hostname.split('.').slice(-2).join('.')}`)) {
-                // remove null values from cookieOptions
                 const filteredOptions = Object.fromEntries(Object.entries(cookieOptions)
-                  .filter(([, propertyValue]) => propertyValue != null));
+                  .filter(([propertyKey, propertyValue]) => {
+                    // remove expires set to Infinity by default
+                    if (propertyKey === 'expires' && propertyValue === 'Infinity') {
+                      return false;
+                    }
+                    // remove null values from cookieOptions
+                    if (propertyValue != null) {
+                      return true;
+                    }
+                    return false;
+                  }));
                 const expressCookieOptions = {
                   ...filteredOptions,
                   ...filteredOptions.maxAge ? { maxAge: cookieOptions.maxAge * 1e3 } : undefined,


### PR DESCRIPTION
- Removes the `tough-cookie` opinion of setting  `expires` to `Infinity` by default. Instead we set it to `undefined`. Per https://expressjs.com/en/api.html#res.cookie

