### PR TITLE
fix(createBrowserLikeFetch): run validation rules first

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -115,6 +115,52 @@ describe('createCookiePassingFetch', () => {
     expect(setCookie).not.toHaveBeenCalled();
   });
 
+  it('does not call setCookie with mismatching public suffix on response', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'mismatchingpublicsuffixtest=123456; Secure; HttpOnly; domain=not-matching-domain.co.uk',
+        ],
+      }),
+    }));
+    const hostname = 'example.co.uk';
+    const setCookie = jest.fn();
+
+    const fetchWithRequestHeaders = createBrowserLikeFetch({
+      hostname,
+      setCookie,
+    })(mockFetch);
+
+    await fetchWithRequestHeaders('https://example.co.uk', {
+      credentials: 'include',
+    });
+
+    expect(setCookie).not.toHaveBeenCalled();
+  });
+
+  it('does not call setCookie with public suffix on response', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'justpublicsuffixtest=123456; Secure; HttpOnly; domain=co.uk',
+        ],
+      }),
+    }));
+    const hostname = 'example.co.uk';
+    const setCookie = jest.fn();
+
+    const fetchWithRequestHeaders = createBrowserLikeFetch({
+      hostname,
+      setCookie,
+    })(mockFetch);
+
+    await fetchWithRequestHeaders('https://example.co.uk', {
+      credentials: 'include',
+    });
+
+    expect(setCookie).not.toHaveBeenCalled();
+  });
+
   it('sends cookies from headers to fetch requests when credentials included and path is a trustedDomain', () => {
     const mockFetch = jest.fn(() => Promise.resolve({}));
     const headers = {
@@ -294,8 +340,9 @@ describe('createCookiePassingFetch', () => {
     const hostname = 'hello.example.com';
 
     const enhancedFetch = createBrowserLikeFetch({ hostname, setCookie })(mockFetch);
-    await enhancedFetch('https://example.org/api/some-resource', { credentials: 'include' });
+    await enhancedFetch('https://example.com/api/some-resource', { credentials: 'include' });
 
+    expect(setCookie).toHaveBeenCalledTimes(1);
     expect(setCookie.mock.calls[0][0]).toEqual('serialized');
     expect(setCookie.mock.calls[0][1]).toEqual('hello:world%🌍');
     expect(setCookie.mock.calls[0][2].domain).toEqual('example.com');

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -14,7 +14,7 @@
  * permissions and limitations under the License.
  */
 
-const { CookieJar, parse } = require('tough-cookie');
+const { CookieJar, parse, getPublicSuffix } = require('tough-cookie');
 const deepMerge = require('./deepMergeObjects');
 
 const constructCookieString = (...fragments) => fragments.filter((fragment) => fragment).join('; ');
@@ -37,6 +37,8 @@ function createBrowserLikeFetch({
   // jar acts as browser's cookie jar for the life of the SSR
   const jar = new CookieJar();
 
+  const dottedHostnamePublicSuffix = hostname && `.${getPublicSuffix(hostname)}`;
+
   return (nextFetch) => (path, options = {}) => {
     let nextFetchOptions = { ...options };
 
@@ -58,21 +60,29 @@ function createBrowserLikeFetch({
           cookieStrings.forEach((cookieString) => {
             const cookie = parse(cookieString);
             const { key, value: valueRaw, ...cookieOptions } = cookie.toJSON();
+            // first run tough-cookie's rules when adding the cookie to the jar
+            // if this throws then the cookie is not valid for the configured hostname either
             try {
-              const value = decodeURIComponent(valueRaw);
-              const cookieDomain = cookieOptions.domain;
-              if (cookieDomain && `.${cookieDomain}`.endsWith(`.${hostname.split('.').slice(-2).join('.')}`)) {
-                const expressCookieOptions = {
-                  ...cookieOptions,
-                  ...cookieOptions.maxAge ? { maxAge: cookieOptions.maxAge * 1e3 } : undefined,
-                };
-                res.cookie(key, value, expressCookieOptions);
-              }
               jar.setCookieSync(cookie, path);
             } catch (error) {
               // eslint-disable-next-line no-console
               console.warn(`Warning: failed to set cookie "${key}" from path "${path}" with the following error, "${error.message}"`);
+              return;
             }
+
+            // then check if this cookie relates to this hostname
+            const cookieDomain = cookieOptions.domain;
+            if (!(cookieDomain && `.${cookieDomain}`.endsWith(dottedHostnamePublicSuffix))) {
+              return;
+            }
+
+            // valid cookie that relates to this hostname, add it to the response cookies set
+            const value = decodeURIComponent(valueRaw);
+            const expressCookieOptions = {
+              ...cookieOptions,
+              ...cookieOptions.maxAge ? { maxAge: cookieOptions.maxAge * 1e3 } : undefined,
+            };
+            res.cookie(key, value, expressCookieOptions);
           });
         }
         return fetchedResp;


### PR DESCRIPTION
## Description
Use tough-cookie rules to determine if the cookie is valid before consideration for `set-cookie` response header.

## Motivation and Context
tough-cookie has a number of rules it follows from specifications, rather than re-implement those in the enhancer we can check if the cookie passes those rules when adding the cookie to the jar.

## How Has This Been Tested?
Public suffix test case included as an example of rules tough-cookie enforces.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
<!--- Please describe how your changes impacts developers using fetch-enhancers. -->
This is a transparent bug fix for users.