### PR TITLE
fix(createBrowserLikeFetch): add trustedURLs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const fetchWithRequestHeaders = createBrowserLikeFetch({
   headers,
   hostname: req.hostname,
   res, // Express response
-  trustedDomains: [/example\.com/],
+  trustedURLs: [/^https:\/\/([^./]+\.)*example\.com(\/.*)?$/],
 })(mockFetch);
 ```
 
@@ -160,18 +160,29 @@ const fetchWithRequestHeaders = createBrowserLikeFetch({
   setCookie: (name, value, options) => res.cookie(name, value, {
     ...options, encode: String,
   }),
-  trustedDomains: [/example\.com/],
+  trustedURLs: [/^https:\/\/([^./]+\.)*example\.com(\/.*)?$/],
 })(mockFetch);
 ```
 
-##### `trustedDomains`
+##### `trustedURLs`
 
-A list of [regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) used to test the path given to fetch when making a request.
+A list of [regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) used to test the first argument given to fetch when making a request.
 If the test is successful the enhanced fetch will include provided cookies.
 
 ```js
-const trustedDomains = [/api\.example\.com/, /another\.example\.com/];
+const trustedURLs = [
+  /^https:\/\/api\.example\.com(\/.*)?$/,
+  /^https:\/\/another\.example\.com(\/.*)?$/,
+  // or, more permissively all subdomains, including none
+  /^https:\/\/([^./]+\.)*example\.com(\/.*)?$/,
+];
 ```
+
+As these are regular expressions, be careful to consider values that you also do **not** want matched (ex: `https://example.com.evil.tld/pwned`).
+
+##### `trustedDomains`
+
+Renamed to `trustedURLs`. Usage of `trustedDomains` is deprecated, but values are added to those of `trustedURLs` until the next breaking version.
 
 #### Example
 
@@ -190,7 +201,7 @@ const fetchWithRequestHeaders = createBrowserLikeFetch({
   headers: parseHeaders(req),
   hostname: req.hostname,
   res, // Express response
-  trustedDomains: [/example\.com/],
+  trustedURLs: [/^https:\/\/([^./]+\.)*example\.com(\/.*)?$/],
 })(mockFetch);
 
 fetchWithRequestHeaders('https://example.com', {

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -118,7 +118,7 @@ function createBrowserLikeFetch({
             // subdomains."
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
             // host includes the hostname and port but getPublicSuffix expects only the hostname
-            cookieOptions.domain = getPublicSuffix(new URL(path).hostname);
+            cookieOptions.domain = getPublicSuffix(new URL(url).hostname);
           }
 
           // then check if this cookie relates to this hostname


### PR DESCRIPTION
## Description
Renames `trustedDomains` to `trustedURLs`, while still accepting `trustedDomains` as a deprecated option.

## Motivation and Context
The values of `trustedDomains` are tested against the full value of the first argument to `fetch`. The first argument to `fetch` in the browser can be a partial URL (ex: just the path) but can also include the domain. Notably on the server, this argument is the full URL as there is no page context (though, side thought, a browser-like fetch might be able to provide that context, perhaps a feature for another PR). The regular expressions provided need to be formulated to handle the argument provided, especially to avoid false-positives (ex: unescaped domain in a query string or the path).

In the future `trustedURLs` may be desired to be removed in favor of some way to test each portion of the parsed URL argument, but for now renaming the option to better reflect what the values are testing against seemed to be the best immediate action.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
<!--- Please describe how your changes impacts developers using fetch-enhancers. -->
Developers will see a warning that `trustedDomains` is deprecated until they use `trustedURLs` instead.