### PR TITLE
test(createBrowserLikeFetch): use jest.spyOn

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -230,10 +230,8 @@ describe('createCookiePassingFetch', () => {
   });
 
   it('should catch, log, and still resolve if a cookie was not able to be set', async () => {
-    const RealConsole = console;
-    const warn = jest.fn();
-    const mockedConsole = { warn };
-    global.console = mockedConsole;
+    jest.spyOn(console, 'warn');
+    console.warn.mockClear();
 
     const invalidDomain = 'example.net';
     const headers = new Headers({
@@ -251,10 +249,8 @@ describe('createCookiePassingFetch', () => {
     await expect(enhancedFetch('https://some-domain.example.com/api/some-resource', { credentials: 'include' }))
       .resolves.toBe(response);
     expect(setCookie).not.toHaveBeenCalled();
-    expect(warn.mock.calls[0][0])
-      .toBe(`Warning: failed to set cookie "id" from path "https://some-domain.example.com/api/some-resource" with the following error, "Cookie not in this host's domain. Cookie:${invalidDomain} Request:some-domain.example.com"`);
-
-    global.console = RealConsole;
+    expect(console.warn.mock.calls[0][0])
+      .toBe('Warning: failed to set cookie "id" from path "https://some-domain.example.com/api/some-resource" with the following error, "Cookie not in this host\'s domain. Cookie:example.net Request:some-domain.example.com"');
   });
 
   it('does not send an empty string cookie header', async () => {


### PR DESCRIPTION
## Description
Avoids irrelevant console errors when the test fails and then does not restore the global variable.

## Motivation and Context
I was a bit confused by "console.warn is not a method" in the terminal while running tests

## How Has This Been Tested?
`$ npm test` 🎤 ⬇️ 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
none, though contributors might have a better time \m/
