### PR TITLE
fix(createBrowserLikeFetch): de-duplicate cookies sent

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -139,6 +139,64 @@ describe('createCookiePassingFetch', () => {
     });
   });
 
+  it('sends un-duplicated cookies from headers and previous fetch responses to fetch requests', async () => {
+    expect.assertions(4);
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'duplicated=fetch-response; Secure; HttpOnly; domain=example.net',
+        ],
+      }),
+    }));
+    const headers = {
+      cookie: 'duplicated=client-request; another=yay',
+    };
+    const trustedDomains = [/^https:\/\/safe-to-send\.example\.net\/.+$/];
+    const hostname = 'www.example.net';
+    const enhancedFetch = createBrowserLikeFetch({ trustedDomains, headers, hostname })(mockFetch);
+
+    await enhancedFetch('https://safe-to-send.example.net/api/some-resource', { credentials: 'include' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await enhancedFetch('https://safe-to-send.example.net/api/some-resource', { credentials: 'include' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1][1]).toHaveProperty('headers.cookie', 'duplicated=fetch-response; another=yay');
+    expect(mockFetch.mock.calls[1][1]).not.toHaveProperty('headers.cookie', 'duplicated=client-request; another=yay');
+  });
+
+  it('sends un-duplicated cookies from headers, previous fetch responses, and current options to fetch requests', async () => {
+    expect.assertions(5);
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'duplicated=fetch-response; Secure; HttpOnly; domain=example.net',
+        ],
+      }),
+    }));
+    const headers = {
+      cookie: 'duplicated=client-request; another=yay',
+    };
+    const trustedDomains = [/^https:\/\/safe-to-send\.example\.net\/.+$/];
+    const hostname = 'www.example.net';
+    const enhancedFetch = createBrowserLikeFetch({ trustedDomains, headers, hostname })(mockFetch);
+
+    await enhancedFetch('https://safe-to-send.example.net/api/some-resource', { credentials: 'include' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await enhancedFetch('https://safe-to-send.example.net/api/some-resource', {
+      credentials: 'include',
+      headers: {
+        cookie: 'duplicated=fetch-option',
+      },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1][1]).toHaveProperty('headers.cookie', 'duplicated=fetch-option; another=yay');
+    expect(mockFetch.mock.calls[1][1]).not.toHaveProperty('headers.cookie', 'duplicated=fetch-response; another=yay');
+    expect(mockFetch.mock.calls[1][1]).not.toHaveProperty('headers.cookie', 'duplicated=client-request; another=yay');
+  });
+
   it('does not send cookies from headers to fetch requests when credentials included and path is not a trustedDomain', () => {
     const mockFetch = jest.fn(() => Promise.resolve({}));
     const headers = {


### PR DESCRIPTION
## Description
Parse the cookies configured and use a `Map` to use the last ones defined for that name.

## Motivation and Context
Sends the cookie only once, rather than each time it is configured in the `headers` option to the fetch creator, fetch response header, or `headers` fetch option. Reduces header size, avoids any conflicting values, and avoids possibly undefined behavior in the fetch'd server/URL.

## How Has This Been Tested?
Just unit tests (included).

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
Smaller header sizes, possibly more memory and CPU usage.