### PR TITLE
fix(createBrowserLikeFetch): use non-subdomain host as default domain

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -115,6 +115,32 @@ describe('createCookiePassingFetch', () => {
     expect(setCookie).not.toHaveBeenCalled();
   });
 
+  it('calls setCookie when using the default the domain attribute when missing in the response', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'sessionid=123456; Secure; HttpOnly',
+        ],
+      }),
+    }));
+    const hostname = 'example.com';
+    const setCookie = jest.fn();
+
+    const fetchWithRequestHeaders = createBrowserLikeFetch({
+      hostname,
+      setCookie,
+    })(mockFetch);
+
+    await fetchWithRequestHeaders('https://www.example.com', {
+      credentials: 'include',
+    });
+
+    expect(setCookie).toHaveBeenCalledTimes(1);
+    expect(setCookie.mock.calls[0][0]).toEqual('sessionid');
+    expect(setCookie.mock.calls[0][1]).toEqual('123456');
+    expect(setCookie.mock.calls[0][2]).toHaveProperty('domain', 'example.com');
+  });
+
   it('sends cookies from headers to fetch requests when credentials included and path is a trustedDomain', () => {
     const mockFetch = jest.fn(() => Promise.resolve({}));
     const headers = {

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -63,7 +63,8 @@ function createBrowserLikeFetch({
               // "If omitted, defaults to the host of the current document URL, not including
               // subdomains."
               // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
-              cookieOptions.domain = getPublicSuffix(new URL(path).host);
+              // host includes the hostname and port but getPublicSuffix expects only the hostname
+              cookieOptions.domain = getPublicSuffix(new URL(path).hostname);
             }
             try {
               const value = decodeURIComponent(valueRaw);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
>Domain=<domain-value> Optional
>Host to which the cookie will be sent.
>* **If omitted, defaults to the host of the current document URL, not including subdomains.**
>* Contrary to earlier specifications, leading dots in domain names (.example.com) are ignored.
>* Multiple host/domain values are not allowed, but if a domain is specified, then subdomains are always included.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes

## Motivation and Context
Not all servers will respond with the Domain attribute and by the specifications it appears they don't have to.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit test added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
<!--- Please describe how your changes impacts developers using fetch-enhancers. -->
More cookies may be returned to clients now (more memory/CPU usage?).
[url.URL](https://nodejs.org/docs/latest-v14.x/api/url.html#url_class_url) was added in Node.js v6.13.0 so developers should not have compatibility issues when they use a version getting security updates.