### PR TITLE
feat(createRetryFetch): adding an enhanced retry fetch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,30 @@ Want to get paid for your contributions to `@americanexpress/fetch-enhancers`?
 
 ## 🤹‍ Usage
 
-* [Installation](#installation)
-* [Fetch Enhancers](#fetch-enhancers)
-* [createTimeoutFetch](#createtimeoutfetch-server--browser)
-* [createRetryFetch](#createretryfetch-server--browser)
-* [createBrowserLikeFetch](#createbrowserlikefetch-server-only)
-* [Composing fetch enhancers](#composing-fetch-enhancers)
-* [Creating your own fetch enhancer](#creating-your-own-fetch-enhancer)
+- [👩‍💻 Hiring 👨‍💻](#-hiring-)
+- [📖 Table of Contents](#-table-of-contents)
+- [🤹‍ Usage](#-usage)
+  - [Installation](#installation)
+  - [Fetch Enhancers](#fetch-enhancers)
+  - [createTimeoutFetch [Server & Browser]](#createtimeoutfetch-server--browser)
+    - [Configuring](#configuring)
+    - [Example](#example)
+  - [createRetryFetch [Server & Browser]](#createretryfetch-server--browser)
+    - [Configuring](#configuring-1)
+    - [Example](#example-1)
+  - [createBrowserLikeFetch [Server only]](#createbrowserlikefetch-server-only)
+    - [Configuring](#configuring-2)
+      - [`headers`](#headers)
+      - [`hostname`](#hostname)
+      - [`res`](#res)
+      - [`setCookie`](#setcookie)
+      - [`trustedDomains`](#trusteddomains)
+    - [Example](#example-2)
+- [Composing fetch enhancers](#composing-fetch-enhancers)
+- [Creating your own fetch enhancer](#creating-your-own-fetch-enhancer)
+- [🏆 Contributing](#-contributing)
+- [🗝️ License](#️-license)
+- [🗣️ Code of Conduct](#️-code-of-conduct)
 
 ### Installation
 
@@ -88,7 +105,7 @@ import { createRetryFetch } from '@americanexpress/fetch-enhancers';
 ```
 
 #### Configuring
-`createRetryFetch` has two arguments: an *optional* retry count (default 3), and an *optional* back off strategy function:
+`createRetryFetch` accepts the an object with the following configuration: an *optional* maxRetry (default 3), and an *optional* back off strategy function:
 
 ```js
 const enhancedRetryFetch = createRetryFetch()(fetch);
@@ -96,8 +113,10 @@ const enhancedRetryFetch = createRetryFetch()(fetch);
 
 Optional retry count and back off strategy function that accepts the current retry count:
 ```js
-const enhancedRetryFetch = createRetryFetch(5,
-  (n) => new Promise((res) => setTimeout(res, n * 1000)))(fetch);
+const enhancedRetryFetch = createRetryFetch({
+  maxRetry: 5,
+  backoffStrategy: (n) => new Promise((res) => setTimeout(res, n * 1000)),
+})(fetch);
 ```
 
 #### Example

--- a/README.md
+++ b/README.md
@@ -88,15 +88,15 @@ import { createRetryFetch } from '@americanexpress/fetch-enhancers';
 ```
 
 #### Configuring
-`createRetryFetch` has three arguments: another enhanced fetch (required), an *optional* retry count, and an *optional* back off strategy function:
+`createRetryFetch` has two arguments: an *optional* retry count (default 3), and an *optional* back off strategy function:
 
 ```js
-const enhancedRetryFetch = createRetryFetch(enhancedTimeoutFetch)(fetch);
+const enhancedRetryFetch = createRetryFetch()(fetch);
 ```
 
 Optional retry count and back off strategy function that accepts the current retry count:
 ```js
-const enhancedRetryFetch = createRetryFetch(enhancedTimeoutFetch, 3,
+const enhancedRetryFetch = createRetryFetch(5,
   (n) => new Promise((res) => setTimeout(res, n * 1000)))(fetch);
 ```
 
@@ -105,7 +105,7 @@ const enhancedRetryFetch = createRetryFetch(enhancedTimeoutFetch, 3,
 ```js
 import { createRetryFetch } from '@americanexpress/fetch-enhancers';
 
-const retryFetch = createRetryFetch(createTimeoutFetch(500))(fetch);
+const retryFetch = createRetryFetch()(createTimeoutFetch(5e3)(fetch));
 
 // Then use retryFetch as you would normally
 const request = retryFetch('https://example.com');

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Want to get paid for your contributions to `@americanexpress/fetch-enhancers`?
 * [Installation](#installation)
 * [Fetch Enhancers](#fetch-enhancers)
 * [createTimeoutFetch](#createtimeoutfetch-server--browser)
+* [createRetryFetch](#createretryfetch-server--browser)
 * [createBrowserLikeFetch](#createbrowserlikefetch-server-only)
 * [Composing fetch enhancers](#composing-fetch-enhancers)
 * [Creating your own fetch enhancer](#creating-your-own-fetch-enhancer)
@@ -79,6 +80,39 @@ request.then((response) => response.json())
 
 // each request can override the default timeout
 const fastRequest = timeoutFetch('https://example.com/fast', { timeout: 1e3 });
+```
+
+### createRetryFetch [Server & Browser]
+```js
+import { createRetryFetch } from '@americanexpress/fetch-enhancers';
+```
+
+#### Configuring
+`createRetryFetch` has three arguments: another enhanced fetch (required), an *optional* retry count, and an *optional* back off strategy function:
+
+```js
+const enhancedRetryFetch = createRetryFetch(enhancedTimeoutFetch)(fetch);
+```
+
+Optional retry count and back off strategy function that accepts the current retry count:
+```js
+const enhancedRetryFetch = createRetryFetch(enhancedTimeoutFetch, 3,
+  (n) => new Promise((res) => setTimeout(res, n * 1000)))(fetch);
+```
+
+#### Example
+
+```js
+import { createRetryFetch } from '@americanexpress/fetch-enhancers';
+
+const retryFetch = createRetryFetch(createTimeoutFetch(500))(fetch);
+
+// Then use retryFetch as you would normally
+const request = retryFetch('https://example.com');
+request.then((response) => response.json())
+  .then((data) => {
+    console.log(data);
+  });
 ```
 
 ### createBrowserLikeFetch [Server only]

--- a/__tests__/createRetryFetch.js
+++ b/__tests__/createRetryFetch.js
@@ -33,10 +33,7 @@ describe('createRetryFetch', () => {
 
   it('should reject on failure', async () => {
     const mockFetch = jest.fn()
-      .mockImplementationOnce(() => Promise.reject(new Error('test rejection error')))
-      .mockImplementationOnce(() => Promise.reject(new Error('test rejection error')))
-      .mockImplementationOnce(() => Promise.reject(new Error('test rejection error')))
-      .mockImplementationOnce(() => Promise.reject(new Error('test rejection error')));
+      .mockImplementation(() => Promise.reject(new Error('test rejection error')));
     const enhancedFetch = createRetryFetch()(mockFetch);
     await expect(enhancedFetch('/')).rejects.toEqual(new Error('test rejection error'));
   });

--- a/__tests__/createRetryFetch.js
+++ b/__tests__/createRetryFetch.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+const createRetryFetch = require('../src/createRetryFetch');
+const createTimeoutFetch = require('../src/createTimeoutFetch');
+const TimeoutError = require('../src/TimeoutError');
+
+function resolveInMs(ms) {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve('Fetch Resolved'), ms);
+  });
+}
+
+describe('createRetryFetch', () => {
+  it('should resolve if the response finishes before the default timeout', async () => {
+    const mockFetch = jest.fn(() => resolveInMs(100));
+    const anotherEnhancedFetch = createTimeoutFetch(500);
+    const enhancedFetch = createRetryFetch(anotherEnhancedFetch)(mockFetch);
+    const promise = enhancedFetch('/test');
+    await expect(promise).resolves.toBe('Fetch Resolved');
+  });
+
+  it('should not retry if the response finishes before the default timeout', async () => {
+    const mockFetch = jest.fn(() => resolveInMs(100));
+    const timeoutFetch = createTimeoutFetch(500);
+    const enhancedFetch = createRetryFetch(timeoutFetch)(mockFetch);
+    const promise = enhancedFetch('/test');
+    await expect(promise).resolves.toBe('Fetch Resolved');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry 3 times (default) if the response takes longer than custom timeout that is shorter than the default', async () => {
+    const mockFetch = jest.fn(() => resolveInMs(500));
+    const timeoutFetch = createTimeoutFetch(100);
+    const enhancedFetch = createRetryFetch(timeoutFetch)(mockFetch);
+    const promise = enhancedFetch('/test');
+    await expect(promise).rejects.toEqual(new TimeoutError('/test after 100ms'));
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('should retry 1 time if the response takes longer than custom timeout that is shorter than the default', async () => {
+    const mockFetch = jest.fn(() => resolveInMs(500));
+    const timeoutFetch = createTimeoutFetch(100);
+    const enhancedFetch = createRetryFetch(timeoutFetch, 1)(mockFetch);
+    const promise = enhancedFetch('/test');
+    await expect(promise).rejects.toEqual(new TimeoutError('/test after 100ms'));
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should run supplied backoff strategy with retry count', async () => {
+    const mockBackoffStrategy = jest.fn((retryCount) => {
+      expect(retryCount).toEqual(1);
+      return Promise.resolve();
+    });
+    const mockFetch = jest.fn(() => resolveInMs(500));
+    const timeoutFetch = createTimeoutFetch(100);
+    const enhancedFetch = createRetryFetch(timeoutFetch, 1, mockBackoffStrategy)(mockFetch);
+    const promise = enhancedFetch('/test');
+    await expect(promise).rejects.toEqual(new TimeoutError('/test after 100ms'));
+    expect(mockBackoffStrategy).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/createRetryFetch.js
+++ b/__tests__/createRetryFetch.js
@@ -24,6 +24,13 @@ describe('createRetryFetch', () => {
     await expect(enhancedFetch('/')).resolves.toBe('Fetch Resolved');
   });
 
+  it('should resolve with invalid config', async () => {
+    const mockFetch = jest.fn()
+      .mockImplementationOnce(() => Promise.resolve('Fetch Resolved'));
+    const enhancedFetch = createRetryFetch({})(mockFetch);
+    await expect(enhancedFetch('/')).resolves.toBe('Fetch Resolved');
+  });
+
   it('should reject on failure', async () => {
     const mockFetch = jest.fn()
       .mockImplementationOnce(() => Promise.reject(new Error('test rejection error')))
@@ -57,23 +64,27 @@ describe('createRetryFetch', () => {
     const mockFetch = jest.fn()
       .mockImplementationOnce(() => Promise.reject(new Error('test rejection error')))
       .mockImplementationOnce(() => Promise.resolve('Fetch Resolved'));
-    const enhancedFetch = createRetryFetch(1)(mockFetch);
+    const enhancedFetch = createRetryFetch({
+      maxRetry: 1,
+    })(mockFetch);
     await expect(enhancedFetch('/')).resolves.toBe('Fetch Resolved');
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it('should run supplied backoff strategy with suppied max retries', async () => {
-    const mockBackoffStrategy = jest.fn((retryCount) => {
+    const backoffStrategy = jest.fn((retryCount) => {
       expect(retryCount).toEqual(1);
       return Promise.resolve();
     });
     const mockFetch = jest.fn()
       .mockImplementationOnce(() => Promise.reject(new Error('test rejection error')))
       .mockImplementationOnce(() => Promise.resolve('Fetch Resolved'));
-    const enhancedFetch = createRetryFetch(1,
-      mockBackoffStrategy)(mockFetch);
+    const enhancedFetch = createRetryFetch({
+      maxRetry: 1,
+      backoffStrategy,
+    })(mockFetch);
     await expect(enhancedFetch('/')).resolves.toBe('Fetch Resolved');
-    expect(mockBackoffStrategy).toHaveBeenCalledTimes(1);
+    expect(backoffStrategy).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/createRetryFetch.js
+++ b/src/createRetryFetch.js
@@ -20,12 +20,11 @@ function defaultBackoffStrategy(retryCount) {
   return new Promise((resolve) => setTimeout(resolve, retryCount * 100));
 }
 
-function createRetryFetch(enhancedFetch,
-  maxRetry = defaultMaxRetry,
+function createRetryFetch(maxRetry = defaultMaxRetry,
   backoffStrategy = defaultBackoffStrategy) {
   let n = 0;
   return (nextFetch) => (path, options = {}) => {
-    const retryFetch = () => enhancedFetch(nextFetch)(path, options)
+    const retryFetch = () => nextFetch(path, options)
       .catch((err) => {
         if (n < maxRetry) {
           n += 1;

--- a/src/createRetryFetch.js
+++ b/src/createRetryFetch.js
@@ -20,8 +20,10 @@ function defaultBackoffStrategy(retryCount) {
   return new Promise((resolve) => setTimeout(resolve, retryCount * 100));
 }
 
-function createRetryFetch(maxRetry = defaultMaxRetry,
-  backoffStrategy = defaultBackoffStrategy) {
+function createRetryFetch({
+  maxRetry = defaultMaxRetry,
+  backoffStrategy = defaultBackoffStrategy,
+} = {}) {
   let n = 0;
   return (nextFetch) => (path, options = {}) => {
     const retryFetch = () => nextFetch(path, options)


### PR DESCRIPTION
Provide an enhanced retry fetch with backoff strategy.

## Description
Provides a simple retry fetch strategy in case an enhanced fetch fails due to network issues. The retry takes an enhanced fetch (required), an optional retry count (default 3), and an optional retry strategy (default retry strategy is a timeout of retryCount * 100ms).

## Motivation and Context
Provide a retry strategy to any future fetch enhancers.

## How Has This Been Tested?
I have added the additional unit tests.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
This change will give retry functionality to enhanced fetch.
