### PR TITLE
fix(createBrowserLikeFetch): skip malformed header cookies

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -293,6 +293,26 @@ describe('createCookiePassingFetch', () => {
     });
   });
 
+  it('skips sending malformed cookies from headers', () => {
+    const mockFetch = jest.fn(() => Promise.resolve({}));
+    const headers = {
+      cookie: 'sessionid=123456;789;much=fun;',
+    };
+    const trustedDomains = [/^https:\/\/safe-to-send\.example\.net\/api\/.+$/];
+    const enhancedFetch = createBrowserLikeFetch({ trustedDomains, headers })(mockFetch);
+
+    enhancedFetch('https://safe-to-send.example.net/api/some-resource', {
+      credentials: 'include',
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://safe-to-send.example.net/api/some-resource', {
+      credentials: 'include',
+      headers: {
+        cookie: 'sessionid=123456; much=fun',
+      },
+    });
+  });
+
   it('does not send cookies from headers to fetch requests when credentials are included and URL is not trusted', () => {
     const mockFetch = jest.fn(() => Promise.resolve({}));
     const headers = {

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -33,7 +33,7 @@ const constructCookieHeader = (...parsedCookies) => [
   .join('; ');
 
 const parseCookieHeader = (cookieHeader) => (cookieHeader
-  ? cookieHeader.split(';').map((individualCookieHeader) => parse(individualCookieHeader))
+  ? cookieHeader.split(';').map((individualCookieHeader) => parse(individualCookieHeader)).filter(Boolean)
   : []
 );
 


### PR DESCRIPTION
## Description
drop cookie values that could not be parsed

## Motivation and Context
When a request cookie could not be parsed the parser returns `undefined`, this causes other issues like property access.
```
Cannot read property 'key' of undefined
```
for [`parsedCookie.key`](https://github.com/americanexpress/fetch-enhancers/blob/v1.1.0/src/createBrowserLikeFetch.js#L26)

## How Has This Been Tested?
tests included

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [x] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
no impact
