### PR TITLE
fix(createBrowserLikeFetch): dont send cookies if credentials=omit

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -357,6 +357,29 @@ describe('createCookiePassingFetch', () => {
     });
   });
 
+  it('does not send cookies from headers to fetch requests when credentials are set to `omit` but URL is trusted', () => {
+    const mockFetch = jest.fn(() => Promise.resolve({}));
+    const headers = {
+      cookie: 'sessionid=123456',
+    };
+    const trustedURLs = [/^https:\/\/safe-to-send\.example\.com\/api\/.+$/];
+    const enhancedFetch = createBrowserLikeFetch({ trustedURLs, headers })(mockFetch);
+
+    enhancedFetch('https://safe-to-send.example.com/api/some-resource', {
+      credentials: 'omit',
+      headers: {
+        'Custom-Header': 'some header for this request',
+      },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://safe-to-send.example.com/api/some-resource', {
+      credentials: 'omit',
+      headers: {
+        'Custom-Header': 'some header for this request',
+      },
+    });
+  });
+
   it('sends along cookies that were set by a previous request', async () => {
     const mockFetch = jest.fn((url) => {
       switch (url) {

--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -212,7 +212,7 @@ describe('createCookiePassingFetch', () => {
   });
 
   it('sends cookies from headers to fetch requests when credentials are set to `same-origin`, and the origins match and URL is trusted', () => {
-    const mockFetch = jest.fn(() => Promise.resolve({}));
+    const mockFetch = jest.fn(() => Promise.resolve({ headers: new Headers() }));
     const headers = {
       cookie: 'sessionid=123456',
     };

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -74,6 +74,10 @@ function createBrowserLikeFetch({
       return nextFetch(url, nextFetchOptions);
     }
 
+    if (options.credentials === 'same-origin' && hostname !== new URL(url).hostname) {
+      return nextFetch(url, nextFetchOptions);
+    }
+
     if (isTrustedURL(url, trustedURLs)) {
       const cookie = constructCookieHeader(
         ...headerCookies,

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -70,7 +70,7 @@ function createBrowserLikeFetch({
   return (nextFetch) => (url, options = {}) => {
     let nextFetchOptions = { ...options };
 
-    if (!options.credentials) {
+    if (!options.credentials || options.credentials === 'omit') {
       return nextFetch(url, nextFetchOptions);
     }
 

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -70,11 +70,11 @@ function createBrowserLikeFetch({
   return (nextFetch) => (url, options = {}) => {
     let nextFetchOptions = { ...options };
 
-    if (!options.credentials || options.credentials === 'omit') {
-      return nextFetch(url, nextFetchOptions);
-    }
-
-    if (options.credentials === 'same-origin' && hostname !== new URL(url).hostname) {
+    if (
+      !options.credentials
+      || options.credentials === 'omit'
+      || (options.credentials === 'same-origin' && hostname !== new URL(url).hostname)
+    ) {
       return nextFetch(url, nextFetchOptions);
     }
 


### PR DESCRIPTION
Fixes #45 

## Description
If the credentials option is set to 'omit' skip cookie processing

## Motivation and Context
This complies with the fetch spec: https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials

## How Has This Been Tested?
Unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
N/A