### PR TITLE
feat(createBrowserLikeFetch): allow for 'same-origin'

### DIFF
--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -74,6 +74,10 @@ function createBrowserLikeFetch({
       return nextFetch(url, nextFetchOptions);
     }
 
+    if (options.credentials === 'same-origin' && hostname !== new URL(url).hostname) {
+      return nextFetch(url, nextFetchOptions);
+    }
+
     if (isTrustedURL(url, trustedURLs)) {
       const cookie = constructCookieHeader(
         ...headerCookies,


### PR DESCRIPTION
extends #45 

## Description
This allows for the 'same-origin' options. 

I added this as a separate PR so we could discuss the breaking nature of this change separately

## Motivation and Context
This complies with the fetch spec: https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials

## How Has This Been Tested?
unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
N/A