### PR TITLE
fix(createBrowserLikeFetch): configure tough-cookie for localhost

### DIFF
--- a/__tests__/createBrowserLikeFetch.spec.js
+++ b/__tests__/createBrowserLikeFetch.spec.js
@@ -601,6 +601,30 @@ describe('createCookiePassingFetch', () => {
     });
   });
 
+  it('correctly calls setCookie when hostname is localhost', async () => {
+    const mockFetch = jest.fn(() => Promise.resolve({
+      headers: new Headers({
+        'set-cookie': [
+          'sessionid=123456; Secure; HttpOnly; domain=localhost; Max-Age=3600',
+        ],
+      }),
+    }));
+    const hostname = 'localhost';
+    const setCookie = jest.fn();
+    const fetchWithRequestHeaders = createBrowserLikeFetch({
+      hostname,
+      setCookie,
+    })(mockFetch);
+
+    await fetchWithRequestHeaders('https://localhost', {
+      credentials: 'include',
+    });
+
+    expect(setCookie.mock.calls[0][0]).toEqual('sessionid');
+    expect(setCookie.mock.calls[0][1]).toEqual('123456');
+    expect(setCookie.mock.calls[0][2].domain).toEqual('localhost');
+  });
+
   it('uses res.cookie to set cookie', async () => {
     const mockFetch = jest.fn(() => Promise.resolve({
       headers: new Headers({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",
-        "tough-cookie": "4.1.3"
+        "tough-cookie": "^4.1.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.10",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "tough-cookie": "4.1.3"
+    "tough-cookie": "^4.1.3"
   },
   "release": {
     "branches": [

--- a/src/createBrowserLikeFetch.js
+++ b/src/createBrowserLikeFetch.js
@@ -63,7 +63,7 @@ function createBrowserLikeFetch({
   // jar acts as browser's cookie jar for the life of the SSR
   const jar = new CookieJar();
 
-  const dottedHostnamePublicSuffix = hostname && `.${getPublicSuffix(hostname)}`;
+  const dottedHostnamePublicSuffix = hostname && `.${getPublicSuffix(hostname, { allowSpecialUseDomain: true })}`;
   // build a list of cookies on creation to ease deduplication on each request
   const headerCookies = parseCookieHeader(headers.cookie);
 
@@ -119,7 +119,9 @@ function createBrowserLikeFetch({
             // subdomains."
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
             // host includes the hostname and port but getPublicSuffix expects only the hostname
-            cookieOptions.domain = getPublicSuffix(new URL(url).hostname);
+            cookieOptions.domain = getPublicSuffix(new URL(url).hostname, {
+              allowSpecialUseDomain: true,
+            });
           }
 
           // then check if this cookie relates to this hostname


### PR DESCRIPTION
## Description
Pass `allowSpecialUseDomains: true` to `getPublicSuffix`.

## Motivation and Context
This allows you to use this when running locally.  Otherwise you get this error:
```
error: error creating store for request Error: Cookie has domain set to the public suffix "localhost" 
which is a special use domain. To allow this, configure your CookieJar with {allowSpecialUseDomain:true, 
rejectPublicSuffixes: false}.
```

tough-cookie@4.1.0 added an options parameter to `getPublicSuffix` and defaulted `allowSpecialUseDomains` to false, which is a breaking change, but they never reverted it.  Also the error message is incorrect, it's not the CookieJar that needs to be configured.
https://github.com/salesforce/tough-cookie/blob/master/lib/pubsuffix-psl.ts#L45C17-L45C17

#50 worked around this by pinning to tough-cookie@4.0.0 but there is a security vulnerability in <4.1.3 so that is not ideal.
https://security.snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873

Note that dependabot PR #53 actually bumped the version to tough-cookie@4.1.3 so the bug fixed by #50 would have come back if a release had been done.

## How Has This Been Tested?
Added unit test.  Also packed and deployed to a module that was having this issue.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for fetch-enhancers users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using fetch-enhancers?
Can upgrade to non-vulnerable tough-cookie.